### PR TITLE
Get actual first item of an array rather than by 0 index when resolving model out of the resource 

### DIFF
--- a/src/Http/SuccessResponseBuilder.php
+++ b/src/Http/SuccessResponseBuilder.php
@@ -206,7 +206,7 @@ class SuccessResponseBuilder extends ResponseBuilder
             return $data;
         }
 
-        $model = $data[0];
+        $model = array_values($data)[0];
         if (! $model instanceof Model) {
             throw new InvalidArgumentException('You can only transform data containing Eloquent models.');
         }


### PR DESCRIPTION
Hello, I found the point where it breaks. When we feed response factory a custom built paginator it fails to resolve model out of the resource because we are manually slicing the collection and when we are on page 2 or 3 we simply don't have an item with `0` index in the array and it's failing to resolve a model. This is not the case when we do `->paginate()` on query builder because it's not slicing a collection, but it adds `limit` and `offset` on actual sql query so we always have 0 indexed element.
