### PR TITLE
Update ResponderServiceProvider.php

### DIFF
--- a/src/ResponderServiceProvider.php
+++ b/src/ResponderServiceProvider.php
@@ -159,7 +159,7 @@ class ResponderServiceProvider extends BaseServiceProvider
         ], 'config');
 
         $this->publishes([
-            __DIR__ . '/../resources/lang/en/errors.php' => resource_path('lang/en/errors.php')
+            __DIR__ . '/../resources/lang/en/errors.php' => base_path('resources/lang/en/errors.php')
         ], 'lang');
     }
 

--- a/src/ResponderServiceProvider.php
+++ b/src/ResponderServiceProvider.php
@@ -159,7 +159,7 @@ class ResponderServiceProvider extends BaseServiceProvider
         ], 'config');
 
         $this->publishes([
-            __DIR__ . '/../resources/lang/en/errors.php' => app_path('resources/lang/en/errors.php')
+            __DIR__ . '/../resources/lang/en/errors.php' => resource_path('lang/en/errors.php')
         ], 'lang');
     }
 


### PR DESCRIPTION
When running `php artisan vendor:publish`, the location of `lang/en/errors.php` file should be in `resources` directory, not in the `app` directory...