### PR TITLE
Add support for error presets

### DIFF
--- a/resources/config/responder.php
+++ b/resources/config/responder.php
@@ -43,23 +43,13 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Error Presets
+    | Custom Exceptions
     |--------------------------------------------------------------------------
-    |
-    | These errors serve as presets to stop the continuous repetition of
-    | error codes and status messages.
-    |
-    | Using them is as easy as follows:
-    | return responder()->error('access_denied');
-    |
     */
 
-    'errors' => [
-        // 'access_denied' => [
-        //     'errorCode'  => 'ERR-ACCESS-DENIED',
-        //     'statusCode' => 403,
-        //     'message'    => 'Access Denied',
-        // ],
+    'exceptions' => [
+        // 'access_denied' => App\Exceptions\AccessDeniedException::class,
+        // ...
     ]
 
 ];

--- a/resources/config/responder.php
+++ b/resources/config/responder.php
@@ -39,6 +39,27 @@ return [
     |
     */
 
-    'load_relations_from_parameter' => 'include'
+    'load_relations_from_parameter' => 'include',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Error Presets
+    |--------------------------------------------------------------------------
+    |
+    | These errors serve as presets to stop the continuous repetition of
+    | error codes and status messages.
+    |
+    | Using them is as easy as follows:
+    | return responder()->error('access_denied');
+    |
+    */
+
+    'errors' => [
+        // 'access_denied' => [
+        //     'errorCode'  => 'ERR-ACCESS-DENIED',
+        //     'statusCode' => 403,
+        //     'message'    => 'Access Denied',
+        // ],
+    ]
 
 ];

--- a/src/Responder.php
+++ b/src/Responder.php
@@ -53,8 +53,10 @@ class Responder
      */
     public function error(string $errorCode = null, int $statusCode = null, $message = null):JsonResponse
     {
-        if ($error = config("responder.errors.$errorCode")) {
-            extract($error);
+        if ($exception = config("responder.exceptions.$errorCode")) {
+            if (class_exists($exception)) {
+                throw new $exception();
+            }
         }
 
         return $this->errorResponse->setError($errorCode, $message)->respond($statusCode);

--- a/src/Responder.php
+++ b/src/Responder.php
@@ -53,6 +53,10 @@ class Responder
      */
     public function error(string $errorCode = null, int $statusCode = null, $message = null):JsonResponse
     {
+        if ($error = config("responder.errors.$errorCode")) {
+            extract($error);
+        }
+
         return $this->errorResponse->setError($errorCode, $message)->respond($statusCode);
     }
 


### PR DESCRIPTION
This PR adds support for error presets which consist of an identifier, error code, status code and message.

```php
'access_denied' => [
    'errorCode'  => 'ERR-ACCESS-DENIED',
    'statusCode' => 403,
    'message'    => 'Access Denied',
],

'bad_gateway' => [
    'errorCode'  => 'ERR-BAD-GATEWAY',
    'statusCode' => 502,
    'message'    => 'Bad Gateway',
],

'bad_request' => [
    'errorCode'  => 'ERR-BAD-REQUEST',
    'statusCode' => 400,
    'message'    => 'Bad Request',
],
```

This allows for an easier, faster and cleaner way of returning errors and stops the continuous repetition of error codes and messages in controllers.

So instead of `return responder()->error('ERR-ACCESS-DENIED', 403, 'Access Denied');` we could then do `responder()->error('access_denied');`.