### PR TITLE
Split relations to include

### DIFF
--- a/src/Http/SuccessResponseBuilder.php
+++ b/src/Http/SuccessResponseBuilder.php
@@ -104,6 +104,10 @@ class SuccessResponseBuilder extends ResponseBuilder
      */
     public function include($relations):SuccessResponseBuilder
     {
+        if (is_string($relations)) {
+            $relations = explode(',', $relations);
+        }
+
         $this->relations = array_merge($this->relations, (array) $relations);
 
         return $this;


### PR DESCRIPTION
At the moment if you visit a url like `http://api.myapp.dev/?include=users,posts` it will try to load the `users,posts` relationship instead of `['users', 'posts']`.