### PR TITLE
Add message property to ApiException

### DIFF
--- a/src/Exceptions/Http/ApiException.php
+++ b/src/Exceptions/Http/ApiException.php
@@ -30,13 +30,20 @@ abstract class ApiException extends HttpException
     protected $errorCode = 'error_occurred';
 
     /**
+     * The error message.
+     *
+     * @var string
+     */
+    protected $message;
+
+    /**
      * Create a new exception instance.
      *
      * @param mixed $message
      */
     public function __construct($message = null)
     {
-        parent::__construct($this->statusCode, $message);
+        parent::__construct($this->statusCode, $this->message ?? $message);
     }
 
     /**


### PR DESCRIPTION
This change allows to set a message inside an exception so the error message doesn't have to be moved to the language file. _I don't know to any API that serves their error messages in multiple languages and this would keep all error related details in one place._

```php
<?php

namespace App\Exceptions;

use Flugg\Responder\Exceptions\Http\ApiException;

class AccessDeniedException extends ApiException
{
    /**
     * The HTTP status code.
     *
     * @var int
     */
    protected $statusCode = 403;

    /**
     * The error code used for API responses.
     *
     * @var string
     */
    protected $errorCode = 'access_denied';

    /**
     * The error message.
     *
     * @var string
     */
    protected $message = 'Access Denied';
}
```