### PR TITLE
Include paginator links

### DIFF
--- a/src/Serializers/ApiSerializer.php
+++ b/src/Serializers/ApiSerializer.php
@@ -82,6 +82,7 @@ class ApiSerializer extends ArraySerializer
             'perPage' => $pagination['per_page'],
             'currentPage' => $pagination['current_page'],
             'totalPages' => $pagination['total_pages'],
+            'links' => $pagination['links'],
         ];
 
         return ['pagination' => $data];

--- a/tests/Integration/MakeSuccessResponseTest.php
+++ b/tests/Integration/MakeSuccessResponseTest.php
@@ -209,7 +209,8 @@ class MakeSuccessResponseTest extends TestCase
                 'count' => 1,
                 'perPage' => 1,
                 'currentPage' => 1,
-                'totalPages' => 1
+                'totalPages' => 1,
+                'links' => []
             ]
         ]);
     }


### PR DESCRIPTION
This will include the links for the next/previous page returned from the Fractal Serializer which allow easy access to the next results