### PR TITLE
Including existing query string values in pagination links

### DIFF
--- a/src/ResourceFactory.php
+++ b/src/ResourceFactory.php
@@ -133,11 +133,9 @@ class ResourceFactory
 
         if ($resource instanceof CollectionResource) {
             $queryParams = array_diff_key(request()->all(), array_flip(['page']));
+            $paginator->appends($queryParams);
 
-            $paginator = new IlluminatePaginatorAdapter($paginator);
-            $paginator->getPaginator()->appends($queryParams);
-
-            $resource->setPaginator($paginator);
+            $resource->setPaginator(new IlluminatePaginatorAdapter($paginator));
         }
 
         return $resource;

--- a/src/ResourceFactory.php
+++ b/src/ResourceFactory.php
@@ -132,7 +132,12 @@ class ResourceFactory
         $resource = static::makeFromCollection($paginator->getCollection());
 
         if ($resource instanceof CollectionResource) {
-            $resource->setPaginator(new IlluminatePaginatorAdapter($paginator));
+            $queryParams = array_diff_key(request()->all(), array_flip(['page']));
+
+            $paginator = new IlluminatePaginatorAdapter($paginator);
+            $paginator->getPaginator()->appends($queryParams);
+
+            $resource->setPaginator($paginator);
         }
 
         return $resource;


### PR DESCRIPTION
Without this change `https://service.com/api/books?include=author` would return `https://service.com/api/books?page=2` as the next page instead of `https://service.com/api/books?include=author&page=2`.


See http://fractal.thephpleague.com/pagination/