### PR TITLE
Make success property optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ composer.lock
 .*.swp
 .swo
 .swp
+*.sublime-project
+*.sublime-workspace

--- a/resources/config/responder.php
+++ b/resources/config/responder.php
@@ -17,6 +17,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Include Success Flag
+    |--------------------------------------------------------------------------
+    |
+    | Wether or not you want to include success flag in your JSON responses.
+    | If true the success flag is prepended to your success and error
+    | responses as either true or false respectively. This takes place right 
+    | after your data is serialized.
+    |
+    */
+
+    'include_success_flag' => true,
+
+    /*
+    |--------------------------------------------------------------------------
     | Include Status Code
     |--------------------------------------------------------------------------
     |

--- a/src/Http/ErrorResponseBuilder.php
+++ b/src/Http/ErrorResponseBuilder.php
@@ -85,11 +85,11 @@ class ErrorResponseBuilder extends ResponseBuilder
     /**
      * Set the error code and optionally an error message.
      *
-     * @param  string|null       $errorCode
+     * @param  mixed|null       $errorCode
      * @param  string|array|null $message
      * @return self
      */
-    public function setError(string $errorCode = null, $message = null):ErrorResponseBuilder
+    public function setError($errorCode = null, $message = null):ErrorResponseBuilder
     {
         $this->errorCode = $errorCode;
 
@@ -114,7 +114,6 @@ class ErrorResponseBuilder extends ResponseBuilder
         if ($statusCode < 400 || $statusCode >= 600) {
             throw new InvalidArgumentException("{$statusCode} is not a valid error HTTP status code.");
         }
-
         return parent::setStatus($statusCode);
     }
 
@@ -126,7 +125,6 @@ class ErrorResponseBuilder extends ResponseBuilder
     public function toArray():array
     {
         return [
-            'success' => false,
             'error' => $this->buildErrorData()
         ];
     }

--- a/src/Http/ErrorResponseBuilder.php
+++ b/src/Http/ErrorResponseBuilder.php
@@ -122,7 +122,7 @@ class ErrorResponseBuilder extends ResponseBuilder
      *
      * @return bool
      */
-    public function isSuccessResponse():bool 
+    protected function isSuccessResponse():bool 
     {
         return false;
     }

--- a/src/Http/ErrorResponseBuilder.php
+++ b/src/Http/ErrorResponseBuilder.php
@@ -118,6 +118,16 @@ class ErrorResponseBuilder extends ResponseBuilder
     }
 
     /**
+     * Return response success flag as true
+     *
+     * @return bool
+     */
+    public function isSuccessResponse():bool 
+    {
+        return false;
+    }
+
+    /**
      * Serialize the data and return as an array.
      *
      * @return array

--- a/src/Http/ResponseBuilder.php
+++ b/src/Http/ResponseBuilder.php
@@ -175,7 +175,7 @@ abstract class ResponseBuilder implements Arrayable, Jsonable, JsonSerializable
             return $data;
         }
 
-        return array_merge([], ['success' => $this->successFlag], $data);
+        return array_merge(['success' => $this->successFlag], $data);
     }
 
     /**
@@ -190,6 +190,6 @@ abstract class ResponseBuilder implements Arrayable, Jsonable, JsonSerializable
             return $data;
         }
 
-        return array_merge([], ['status' => $this->statusCode], $data);
+        return array_merge(['status' => $this->statusCode], $data);
     }
 }

--- a/src/Http/ResponseBuilder.php
+++ b/src/Http/ResponseBuilder.php
@@ -69,15 +69,13 @@ abstract class ResponseBuilder implements Arrayable, Jsonable, JsonSerializable
      *
      * @param  int|null $statusCode
      * @param  array    $headers
-     * @param  bool     $successFlag
      * @return \Illuminate\Http\JsonResponse
      */
-    public function respond(int $statusCode = null, array $headers = [], bool $successFlag = true):JsonResponse
+    public function respond(int $statusCode = null, array $headers = []):JsonResponse
     {
         if (! is_null($statusCode)) {
             $this->setStatus($statusCode);
         }
-        $this->successFlag = $successFlag;
 
         $data = $this->toArray();
         $data = $this->includeStatusCode($data);
@@ -98,6 +96,13 @@ abstract class ResponseBuilder implements Arrayable, Jsonable, JsonSerializable
 
         return $this;
     }
+
+    /**
+     * Return response success flag
+     *
+     * @return bool
+     */
+    abstract public function isSuccessResponse():bool;
 
     /**
      * Set a flag indicating if success should be added to the response.
@@ -175,7 +180,7 @@ abstract class ResponseBuilder implements Arrayable, Jsonable, JsonSerializable
             return $data;
         }
 
-        return array_merge(['success' => $this->successFlag], $data);
+        return array_merge(['success' => $this->isSuccessResponse()], $data);
     }
 
     /**

--- a/src/Http/ResponseBuilder.php
+++ b/src/Http/ResponseBuilder.php
@@ -95,7 +95,7 @@ abstract class ResponseBuilder implements Arrayable, Jsonable, JsonSerializable
      *
      * @return bool
      */
-    abstract public function isSuccessResponse():bool;
+    abstract protected function isSuccessResponse():bool;
 
     /**
      * Set a flag indicating if success should be added to the response.

--- a/src/Http/ResponseBuilder.php
+++ b/src/Http/ResponseBuilder.php
@@ -34,13 +34,6 @@ abstract class ResponseBuilder implements Arrayable, Jsonable, JsonSerializable
     protected $includeStatusCode;
 
     /**
-     * The success flag property
-     *
-     * @var bool
-     */
-    protected $successFlag;
-
-    /**
      * The HTTP status code for the response.
      *
      * @var int

--- a/src/Http/ResponseBuilder.php
+++ b/src/Http/ResponseBuilder.php
@@ -72,31 +72,18 @@ abstract class ResponseBuilder implements Arrayable, Jsonable, JsonSerializable
      * @param  bool     $successFlag
      * @return \Illuminate\Http\JsonResponse
      */
-    public function respond(int $statusCode = null, array $headers = [], bool $successFlag = false):JsonResponse
+    public function respond(int $statusCode = null, array $headers = [], bool $successFlag = true):JsonResponse
     {
         if (! is_null($statusCode)) {
             $this->setStatus($statusCode);
         }
-        $this->setSuccess($successFlag);
+        $this->successFlag = $successFlag;
 
         $data = $this->toArray();
         $data = $this->includeStatusCode($data);
         $data = $this->includeSuccessFlag($data);
 
         return $this->responseFactory->json($data, $this->statusCode, $headers);
-    }
-
-    /**
-     * Set the response success flag
-     *
-     * @param  bool $successFlag
-     * @return self
-     */
-    public function setSuccess(bool $successFlag):ResponseBuilder
-    {
-        $this->successFlag = $successFlag;
-
-        return $this;
     }
 
     /**

--- a/src/Http/SuccessResponseBuilder.php
+++ b/src/Http/SuccessResponseBuilder.php
@@ -147,7 +147,7 @@ class SuccessResponseBuilder extends ResponseBuilder
      *
      * @return bool
      */
-    public function isSuccessResponse():bool 
+    protected function isSuccessResponse():bool 
     {
         return true;
     }

--- a/src/Http/SuccessResponseBuilder.php
+++ b/src/Http/SuccessResponseBuilder.php
@@ -143,6 +143,16 @@ class SuccessResponseBuilder extends ResponseBuilder
     }
 
     /**
+     * Return response success flag as true
+     *
+     * @return bool
+     */
+    public function isSuccessResponse():bool 
+    {
+        return true;
+    }
+
+    /**
      * Set the transformation data. This will set a new resource instance on the response
      * builder depending on what type of data is provided.
      *

--- a/src/Responder.php
+++ b/src/Responder.php
@@ -46,12 +46,12 @@ class Responder
     /**
      * Generate an error JSON response.
      *
-     * @param  string|null $errorCode
+     * @param  mixed|null $errorCode
      * @param  int|null    $statusCode
      * @param  mixed       $message
      * @return \Illuminate\Http\JsonResponse
      */
-    public function error(string $errorCode = null, int $statusCode = null, $message = null):JsonResponse
+    public function error($errorCode = null, int $statusCode = null, $message = null):JsonResponse
     {
         if ($exception = config("responder.exceptions.$errorCode")) {
             if (class_exists($exception)) {
@@ -59,7 +59,7 @@ class Responder
             }
         }
 
-        return $this->errorResponse->setError($errorCode, $message)->respond($statusCode);
+        return $this->errorResponse->setError($errorCode, $message)->respond($statusCode, [], false);
     }
 
     /**

--- a/src/Responder.php
+++ b/src/Responder.php
@@ -59,7 +59,7 @@ class Responder
             }
         }
 
-        return $this->errorResponse->setError($errorCode, $message)->respond($statusCode, [], false);
+        return $this->errorResponse->setError($errorCode, $message)->respond($statusCode);
     }
 
     /**

--- a/src/ResponderServiceProvider.php
+++ b/src/ResponderServiceProvider.php
@@ -123,12 +123,14 @@ class ResponderServiceProvider extends BaseServiceProvider
                 $builder->include($this->app[Request::class]->input($parameter, []));
             }
 
+            return $builder->setIncludeSuccessFlag($app->config->get('responder.include_success_flag'));
             return $builder->setIncludeStatusCode($app->config->get('responder.include_status_code'));
         });
 
         $this->app->bind(ErrorResponseBuilder::class, function ($app) {
             $builder = new ErrorResponseBuilder(response(), $app['translator']);
 
+            return $builder->setIncludeSuccessFlag($app->config->get('responder.include_success_flag'));
             return $builder->setIncludeStatusCode($app->config->get('responder.include_status_code'));
         });
     }

--- a/src/Serializers/ApiSerializer.php
+++ b/src/Serializers/ApiSerializer.php
@@ -49,7 +49,6 @@ class ApiSerializer extends ArraySerializer
     public function null()
     {
         return [
-            'success' => true,
             'data' => null
         ];
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -57,6 +57,7 @@ abstract class TestCase extends BaseTestCase
     {
         parent::setUp();
 
+        $this->app['config']->set('responder.include_success_flag', true);
         $this->app['config']->set('responder.include_status_code', false);
         $this->responder = $this->app[Responder::class];
 

--- a/tests/Unit/ErrorResponseBuilderTest.php
+++ b/tests/Unit/ErrorResponseBuilderTest.php
@@ -88,26 +88,6 @@ class ErrorResponseBuilderTest extends TestCase
     }
 
     /**
-     * Test that the [respond] method allows passing a success flag as third parameter.
-     * to the [respond] method.
-     *
-     * @test
-     */
-    public function respondMethodShouldAllowSettingSuccessFlag()
-    {
-        // Arrange...
-        $responseBuilder = $this->app->make('responder.error');
-
-        // Act...
-        $response = $responseBuilder->respond(400, [], false);
-        $responseArray = json_decode($response->content(), true);
-
-        // Assert...
-        $this->assertArrayHasKey('success', $responseArray);
-        $this->assertEquals(false, $responseArray['success']);
-    }
-
-    /**
      * Test that the [setStatus] method sets the HTTP status code on the response, providing
      * an alternative, more explicit way of setting the status code.
      *

--- a/tests/Unit/ErrorResponseBuilderTest.php
+++ b/tests/Unit/ErrorResponseBuilderTest.php
@@ -44,10 +44,29 @@ class ErrorResponseBuilderTest extends TestCase
 
         // Act...
         $response = $responseBuilder->respond();
+        $responseArray = json_decode($response->content(), true);
 
         // Assert...
         $this->assertInstanceOf(JsonResponse::class, $response);
         $this->assertEquals($response->status(), 500);
+        $this->assertArrayHasKey('success', $responseArray);
+        $this->assertEquals(false, $responseArray['success']);
+    }
+
+    /**
+     * Test that the [respond] method does not respond with success flag
+     *
+     * @test
+     */
+    public function respondMethodShouldNotOutputSuccessFlagWhenDisabled()
+    {
+        $this->app['config']->set('responder.include_success_flag', false);
+        $responseBuilder = $this->app->make('responder.success');
+
+        $response = $responseBuilder->respond();
+        $responseArray = json_decode($response->content(), true);
+
+        $this->assertArrayNotHasKey('success', $responseArray);
     }
 
     /**

--- a/tests/Unit/ErrorResponseBuilderTest.php
+++ b/tests/Unit/ErrorResponseBuilderTest.php
@@ -175,7 +175,6 @@ class ErrorResponseBuilderTest extends TestCase
 
         // Assert...
         $this->assertEquals([
-            'success' => false,
             'error' => null
         ], $array);
     }
@@ -195,7 +194,6 @@ class ErrorResponseBuilderTest extends TestCase
 
         // Assert...
         $this->assertEquals([
-            'success' => false,
             'error' => [
                 'code' => 'testing_error',
                 'message' => null
@@ -219,7 +217,6 @@ class ErrorResponseBuilderTest extends TestCase
 
         // Assert...
         $this->assertEquals([
-            'success' => false,
             'error' => [
                 'code' => 'testing_error',
                 'message' => 'Testing error'
@@ -245,7 +242,6 @@ class ErrorResponseBuilderTest extends TestCase
 
         // Assert...
         $this->assertEquals([
-            'success' => false,
             'error' => [
                 'code' => 'testing_error',
                 'message' => 'Testing error foo'
@@ -271,7 +267,6 @@ class ErrorResponseBuilderTest extends TestCase
 
         // Assert...
         $this->assertEquals([
-            'success' => false,
             'error' => [
                 'code' => 'testing_error',
                 'message' => 'Testing error 2'
@@ -294,7 +289,6 @@ class ErrorResponseBuilderTest extends TestCase
 
         // Assert...
         $this->assertEquals(collect([
-            'success' => false,
             'error' => null
         ]), $collection);
     }
@@ -314,7 +308,6 @@ class ErrorResponseBuilderTest extends TestCase
 
         // Assert...
         $this->assertEquals(json_encode([
-            'success' => false,
             'error' => null
         ]), $json);
     }

--- a/tests/Unit/ErrorResponseBuilderTest.php
+++ b/tests/Unit/ErrorResponseBuilderTest.php
@@ -88,6 +88,26 @@ class ErrorResponseBuilderTest extends TestCase
     }
 
     /**
+     * Test that the [respond] method allows passing a success flag as third parameter.
+     * to the [respond] method.
+     *
+     * @test
+     */
+    public function respondMethodShouldAllowSettingSuccessFlag()
+    {
+        // Arrange...
+        $responseBuilder = $this->app->make('responder.error');
+
+        // Act...
+        $response = $responseBuilder->respond(400, [], false);
+        $responseArray = json_decode($response->content(), true);
+
+        // Assert...
+        $this->assertArrayHasKey('success', $responseArray);
+        $this->assertEquals(false, $responseArray['success']);
+    }
+
+    /**
      * Test that the [setStatus] method sets the HTTP status code on the response, providing
      * an alternative, more explicit way of setting the status code.
      *

--- a/tests/Unit/SuccessResponseBuilderTest.php
+++ b/tests/Unit/SuccessResponseBuilderTest.php
@@ -616,26 +616,6 @@ class SuccessResponseBuilderTest extends TestCase
     }
 
     /**
-     * Test that the [respond] method allows passing a success flag as third parameter.
-     * to the [respond] method.
-     *
-     * @test
-     */
-    public function respondMethodShouldAllowSettingSuccessFlag()
-    {
-        // Arrange...
-        $responseBuilder = $this->app->make('responder.success');
-
-        // Act...
-        $response = $responseBuilder->respond(201, [], true);
-        $responseArray = json_decode($response->content(), true);
-
-        // Assert...
-        $this->assertArrayHasKey('success', $responseArray);
-        $this->assertEquals(true, $responseArray['success']);
-    }
-
-    /**
      * Test that the [setStatus] method sets the HTTP status code on the response, providing
      * an alternative, more explicit way of setting the status code.
      *

--- a/tests/Unit/SuccessResponseBuilderTest.php
+++ b/tests/Unit/SuccessResponseBuilderTest.php
@@ -616,6 +616,26 @@ class SuccessResponseBuilderTest extends TestCase
     }
 
     /**
+     * Test that the [respond] method allows passing a success flag as third parameter.
+     * to the [respond] method.
+     *
+     * @test
+     */
+    public function respondMethodShouldAllowSettingSuccessFlag()
+    {
+        // Arrange...
+        $responseBuilder = $this->app->make('responder.success');
+
+        // Act...
+        $response = $responseBuilder->respond(201, [], true);
+        $responseArray = json_decode($response->content(), true);
+
+        // Assert...
+        $this->assertArrayHasKey('success', $responseArray);
+        $this->assertEquals(true, $responseArray['success']);
+    }
+
+    /**
      * Test that the [setStatus] method sets the HTTP status code on the response, providing
      * an alternative, more explicit way of setting the status code.
      *
@@ -683,7 +703,6 @@ class SuccessResponseBuilderTest extends TestCase
 
         // Assert...
         $this->assertEquals([
-            'success' => true,
             'data' => null
         ], $array);
     }
@@ -724,7 +743,6 @@ class SuccessResponseBuilderTest extends TestCase
 
         // Assert...
         $this->assertEquals(collect([
-            'success' => true,
             'data' => null
         ]), $collection);
     }
@@ -744,7 +762,6 @@ class SuccessResponseBuilderTest extends TestCase
 
         // Assert...
         $this->assertEquals(json_encode([
-            'success' => true,
             'data' => null
         ]), $json);
     }

--- a/tests/Unit/SuccessResponseBuilderTest.php
+++ b/tests/Unit/SuccessResponseBuilderTest.php
@@ -572,10 +572,29 @@ class SuccessResponseBuilderTest extends TestCase
 
         // Act...
         $response = $responseBuilder->respond();
+        $responseArray = json_decode($response->content(), true);
 
         // Assert...
         $this->assertInstanceOf(JsonResponse::class, $response);
         $this->assertEquals($response->status(), 200);
+        $this->assertArrayHasKey('success', $responseArray);
+        $this->assertEquals(true, $responseArray['success']);
+    }
+
+    /**
+     * Test that the [respond] method does not respond with success flag
+     *
+     * @test
+     */
+    public function respondMethodShouldNotOutputSuccessFlagWhenDisabled()
+    {
+        $this->app['config']->set('responder.include_success_flag', false);
+        $responseBuilder = $this->app->make('responder.success');
+
+        $response = $responseBuilder->respond();
+        $responseArray = json_decode($response->content(), true);
+
+        $this->assertArrayNotHasKey('success', $responseArray);
     }
 
     /**


### PR DESCRIPTION
Looking to make the success property optional as it is redundant when validating a response from a client.