### PR TITLE
Automatic resolving of resource keys

### DIFF
--- a/src/Contracts/Resources/ResourceKeyResolver.php
+++ b/src/Contracts/Resources/ResourceKeyResolver.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Flugg\Responder\Contracts\Resources;
+
+/**
+ * A contract for resolving resource keys.
+ *
+ * @package flugger/laravel-responder
+ * @author  Alexander Tømmerås <flugged@gmail.com>
+ * @license The MIT License
+ */
+interface ResourceKeyResolver
+{
+    /**
+     * Register a transformable to resource key binding.
+     *
+     * @param  string|array $transformable
+     * @param  string       $resourceKey
+     * @return void
+     */
+    public function bind($transformable, string $resourceKey);
+
+    /**
+     * Resolve a resource key from the given data.
+     *
+     * @param  mixed $data
+     * @return string|null
+     */
+    public function resolve($data);
+}

--- a/src/Resources/ResourceFactory.php
+++ b/src/Resources/ResourceFactory.php
@@ -3,6 +3,7 @@
 namespace Flugg\Responder\Resources;
 
 use Flugg\Responder\Contracts\Resources\ResourceFactory as ResourceFactoryContract;
+use Flugg\Responder\Contracts\Resources\ResourceKeyResolver;
 use Flugg\Responder\Contracts\Transformers\TransformerResolver;
 use Illuminate\Support\Arr;
 use League\Fractal\Resource\Collection as CollectionResource;
@@ -35,15 +36,24 @@ class ResourceFactory implements ResourceFactoryContract
     protected $transformerResolver;
 
     /**
+     * A resolver class, used to resolve resource keys.
+     *
+     * @var \Flugg\Responder\Contracts\Resources\ResourceKeyResolver
+     */
+    protected $resourceKeyResolver;
+
+    /**
      * Construct the factory class.
      *
      * @param \Flugg\Responder\Resources\DataNormalizer                   $normalizer
      * @param \Flugg\Responder\Contracts\Transformers\TransformerResolver $transformerResolver
+     * @param \Flugg\Responder\Contracts\Resources\ResourceKeyResolver    $resourceKeyResolver
      */
-    public function __construct(DataNormalizer $normalizer, TransformerResolver $transformerResolver)
+    public function __construct(DataNormalizer $normalizer, TransformerResolver $transformerResolver, ResourceKeyResolver $resourceKeyResolver)
     {
         $this->normalizer = $normalizer;
         $this->transformerResolver = $transformerResolver;
+        $this->resourceKeyResolver = $resourceKeyResolver;
     }
 
     /**
@@ -57,12 +67,14 @@ class ResourceFactory implements ResourceFactoryContract
     public function make($data = null, $transformer = null, string $resourceKey = null): ResourceInterface
     {
         if ($data instanceof ResourceInterface) {
-            return $data->setTransformer($this->resolveTransformer($data->getData(), $transformer ?: $data->getTransformer()));
+            return $data->setTransformer($this->resolveTransformer($data->getData(), $transformer ?: $data->getTransformer()))
+                ->setResourceKey($this->resolveResourceKey($data->getData(), $resourceKey ?: $data->getResourceKey()));
         } elseif (is_null($data = $this->normalizer->normalize($data))) {
-            return $this->instatiateResource($data);
+            return $this->instatiateResource($data, null, $resourceKey);
         }
 
         $transformer = $this->resolveTransformer($data, $transformer);
+        $resourceKey = $this->resolveResourceKey($data, $resourceKey);
 
         return $this->instatiateResource($data, $transformer, $resourceKey);
     }
@@ -84,6 +96,18 @@ class ResourceFactory implements ResourceFactoryContract
     }
 
     /**
+     * Resolve a resource key.
+     *
+     * @param  mixed       $data
+     * @param  string|null $resourceKey
+     * @return null|string
+     */
+    protected function resolveResourceKey($data, string $resourceKey = null)
+    {
+        return isset($resourceKey) ? $resourceKey : $this->resourceKeyResolver->resolve($data);
+    }
+
+    /**
      * Instatiate a new resource instance.
      *
      * @param  mixed                                                   $data
@@ -94,7 +118,7 @@ class ResourceFactory implements ResourceFactoryContract
     protected function instatiateResource($data, $transformer = null, string $resourceKey = null): ResourceInterface
     {
         if (is_null($data)) {
-            return new NullResource;
+            return new NullResource(null, null, $resourceKey);
         } elseif ($this->shouldCreateCollection($data)) {
             return new CollectionResource($data, $transformer, $resourceKey);
         }

--- a/src/Resources/ResourceKeyResolver.php
+++ b/src/Resources/ResourceKeyResolver.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Flugg\Responder\Resources;
+
+use Flugg\Responder\Contracts\Resources\ResourceKeyResolver as ResourceKeyResolverContract;
+use Illuminate\Database\Eloquent\Model;
+use Traversable;
+
+/**
+ * This class is responsible for resolving resource keys.
+ *
+ * @package flugger/laravel-responder
+ * @author  Alexander Tømmerås <flugged@gmail.com>
+ * @license The MIT License
+ */
+class ResourceKeyResolver implements ResourceKeyResolverContract
+{
+    /**
+     * Transformable to resource key mappings.
+     *
+     * @var array
+     */
+    protected $bindings = [];
+
+    /**
+     * Register a transformable to resource key binding.
+     *
+     * @param  string|array $transformable
+     * @param  string       $resourceKey
+     * @return void
+     */
+    public function bind($transformable, string $resourceKey)
+    {
+        $this->bindings = array_merge($this->bindings, is_array($transformable) ? $transformable : [
+            $transformable => $resourceKey,
+        ]);
+    }
+
+    /**
+     * Resolve a resource key from the given data.
+     *
+     * @param  mixed $data
+     * @return string|null
+     */
+    public function resolve($data)
+    {
+        $transformable = $this->resolveTransformable($data);
+
+        if (is_object($transformable) && key_exists(get_class($transformable), $this->bindings)) {
+            return $this->bindings[get_class($transformable)];
+        }
+
+        if ($transformable instanceof Model) {
+            return $this->resolveFromModel($transformable);
+        }
+
+        return null;
+    }
+
+    /**
+     * Resolve a transformable from the given data.
+     *
+     * @param  mixed $data
+     * @return mixed
+     */
+    protected function resolveTransformable($data)
+    {
+        if (is_array($data) || $data instanceof Traversable) {
+            foreach ($data as $item) {
+                return $item;
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * Resolve a resource key from the given model.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model $model
+     * @return string
+     */
+    protected function resolveFromModel(Model $model)
+    {
+        if (method_exists($model, 'getResourceKey')) {
+            return $model->getResourceKey();
+        }
+
+        return $model->getTable();
+    }
+}

--- a/src/ResponderServiceProvider.php
+++ b/src/ResponderServiceProvider.php
@@ -8,6 +8,7 @@ use Flugg\Responder\Contracts\ErrorMessageResolver as ErrorMessageResolverContra
 use Flugg\Responder\Contracts\ErrorSerializer as ErrorSerializerContract;
 use Flugg\Responder\Contracts\Pagination\PaginatorFactory as PaginatorFactoryContract;
 use Flugg\Responder\Contracts\Resources\ResourceFactory as ResourceFactoryContract;
+use Flugg\Responder\Contracts\Resources\ResourceKeyResolver as ResourceKeyResolverContract;
 use Flugg\Responder\Contracts\Responder as ResponderContract;
 use Flugg\Responder\Contracts\ResponseFactory as ResponseFactoryContract;
 use Flugg\Responder\Contracts\Transformer as TransformerContract;
@@ -18,6 +19,7 @@ use Flugg\Responder\Http\Responses\Factories\LaravelResponseFactory;
 use Flugg\Responder\Http\Responses\Factories\LumenResponseFactory;
 use Flugg\Responder\Pagination\PaginatorFactory;
 use Flugg\Responder\Resources\ResourceFactory;
+use Flugg\Responder\Resources\ResourceKeyResolver;
 use Flugg\Responder\Transformers\Transformer as BaseTransformer;
 use Flugg\Responder\Transformers\TransformerResolver;
 use Illuminate\Contracts\Container\Container;
@@ -162,6 +164,10 @@ class ResponderServiceProvider extends BaseServiceProvider
      */
     protected function registerResourceBindings()
     {
+        $this->app->singleton(ResourceKeyResolverContract::class, function ($app) {
+            return $app->make(ResourceKeyResolver::class);
+        });
+
         $this->app->singleton(ResourceFactoryContract::class, function ($app) {
             return $app->make(ResourceFactory::class);
         });

--- a/tests/Unit/Resources/ResolveResourceKeyTest.php
+++ b/tests/Unit/Resources/ResolveResourceKeyTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Flugg\Responder\Tests\Unit\Resources;
+
+use Flugg\Responder\Resources\ResourceKeyResolver;
+use Flugg\Responder\Tests\TestCase;
+use Illuminate\Database\Eloquent\Model;
+use Mockery;
+
+/**
+ * Unit tests for the [Flugg\Responder\Resources\ResolveResourceKeyTest] class.
+ *
+ * @package flugger/laravel-responder
+ * @author  Alexander Tømmerås <flugged@gmail.com>
+ * @license The MIT License
+ */
+class ResolveResourceKeyTest extends TestCase
+{
+    /**
+     * The [ResourceKeyResolver] class being tested.
+     *
+     * @var \Flugg\Responder\Resources\ResourceKeyResolver
+     */
+    protected $resolver;
+
+    /**
+     * Setup the test environment.
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->resolver = new ResourceKeyResolver;
+    }
+
+    /**
+     * Assert that the [resolve] method resolves null as resource key if it can't resolve a resource
+     * key from the given data.
+     */
+    public function testResolveMethodShouldResolveNullAsResourceKeyIfNoneIsFound()
+    {
+        $result = $this->resolver->resolve($data = []);
+
+        $this->assertNull($result);
+    }
+
+    /**
+     * Assert that the [resolve] method resolves resource key from cache if binding is set.
+     */
+    public function testResolveMethodShouldResolveResourceKeyFromBinding()
+    {
+        $model = Mockery::mock(Model::class);
+        $this->resolver->bind(get_class($model), $resourceKey = 'foo');
+
+        $result = $this->resolver->resolve($model);
+
+        $this->assertEquals($resourceKey, $result);
+    }
+
+    /**
+     * Assert that the [resolve] method resolves transformable from a list of transformables.
+     */
+    public function testResolveMethodShouldResolveTransformableFromArray()
+    {
+        $data = [$model = Mockery::mock(Model::class)];
+        $this->resolver->bind(get_class($model), $resourceKey = 'foo');
+
+        $result = $this->resolver->resolve($data);
+
+        $this->assertEquals($resourceKey, $result);
+    }
+
+    /**
+     * Assert that the [resolve] method resolves resource key from the model's table name.
+     */
+    public function testResolveMethodShouldResolveResourceKeyFromModelsTable()
+    {
+        $model = Mockery::mock(Model::class);
+        $model->shouldReceive('getTable')->andReturn($resourceKey = 'foo');
+
+        $result = $this->resolver->resolve($model);
+
+        $this->assertEquals($resourceKey, $result);
+    }
+
+    /**
+     * Assert that the [resolve] method resolves resource key from the [getResourceKey] method.
+     */
+    public function testResolveMethodShouldResolveResourceKeyFromGetResourceKeyIfMethodExists()
+    {
+        $model = new class extends Model {
+            public function getResourceKey() { return 'foo'; }
+        };
+
+        $result = $this->resolver->resolve($model);
+
+        $this->assertEquals('foo', $result);
+    }
+}


### PR DESCRIPTION
Currently the `only` method uses the `parseFieldsets` of Fractal which requires resource keys to be set. Running `only` without setting resource key return in a LogicException: "Filtering fields using sparse fieldsets require resource key to be set.". 

This PR adds a new `ResourceKeyResolver` for automatically resolving a resource key from a model. If a `getResourceKey` method is set, it will use that, else it will fall back to the `getTable` method. This way people wont have to manually set resource key for each response.

I will also work on updating the documentation accordingly before merging.