### PR TITLE
Fractal parameters bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,6 +633,10 @@ return $this->resource($product->shipments, new ShipmentTransformer);
 _You should be careful with executing any new database calls inside the include methods as you might end up with an unexpected amount of hits to the database._
 ***
 
+#### Using parameters
+
+Parameters management is totally delegated to the underlying Fractal library (see it's [documentation](https://fractal.thephpleague.com/transformers/#include-parameters)) except from the fact that parameters are provided directly as an array instead of a `\League\Fractal\ParamBag`.
+
 #### Setting Available Relationships
 
 The `$relations` property specifies a list of relations available to be included. When you generate a transformer, the `$relations` property will be equal to a wildcard, allowing all relations on the transformer:

--- a/src/TransformBuilder.php
+++ b/src/TransformBuilder.php
@@ -251,7 +251,7 @@ class TransformBuilder
         }
 
         if ($data instanceof Model || $data instanceof Collection) {
-            $data->load($this->with);
+            $data->load($this->relationsWithoutParameters());
         }
 
         $this->with = $this->stripEagerLoadConstraints($this->with);
@@ -286,5 +286,28 @@ class TransformBuilder
         return collect($relations)->map(function ($value, $key) {
             return is_numeric($key) ? $value : $key;
         })->values()->all();
+    }
+
+    /**
+     * Remove parameters from relations that must be loaded.
+     *
+     * @return array
+     */
+    protected function relationsWithoutParameters(): array
+    {
+        $cleanedRelations = [];
+        foreach ($this->with as $key => $value) {
+            // If the key is numeric, value is the relation name:
+            //  we remove parameters from the value and return the relation name
+            // Otherwise the key is the relation name and the value is a custom scope:
+            //  we remove parameters from the key and return the relation with the value untouched
+            if(is_numeric($key)) {
+                $cleanedRelations[$key] = explode(':', $value)[0];
+            } else {
+                $cleanedRelations[explode(':', $key)[0]] = $value;
+            }
+        }
+
+        return $cleanedRelations;
     }
 }

--- a/tests/Unit/TransformBuilderTest.php
+++ b/tests/Unit/TransformBuilderTest.php
@@ -316,6 +316,30 @@ class TransformBuilderTest extends TestCase
     }
 
     /**
+     * Assert that the [transform] method extracts default relationships from transformer and
+     * automatically eager loads all relationships.
+     */
+    public function testTransformMethodExtractsAndEagerLoadsRelationsWhenThereAreRelationParameters()
+    {
+        $this->transformFactory->shouldReceive('make')->andReturn([]);
+        $this->resource->shouldReceive('getData')->andReturn($model = Mockery::mock(Model::class));
+        $model->shouldReceive('load')->andReturnSelf();
+        $this->resource->shouldReceive('getTransformer')->andReturn($transformer = Mockery::mock(Transformer::class));
+        $transformer->shouldReceive('defaultRelations')->andReturn([]);
+
+        $this->builder->resource()->with($relations = ['foo:first(aa|bb)','bar:second(cc|dd)'])->transform();
+
+        // Model should receive the relations names without parameters,
+        //  while the transformFactory should receive also parameters to let Fractal use them
+        $model->shouldHaveReceived('load')->with(['foo','bar'])->once();
+        $this->transformFactory->shouldHaveReceived('make')->with($this->resource, $this->serializer, [
+            'includes' => $relations,
+            'excludes' => [],
+            'fieldsets' => [],
+        ])->once();
+    }
+
+    /**
      * Assert that the [only] method sets the filtered fields that are sent to the
      * [TransformFactory].
      */

--- a/tests/Unit/TransformBuilderTest.php
+++ b/tests/Unit/TransformBuilderTest.php
@@ -317,7 +317,7 @@ class TransformBuilderTest extends TestCase
 
     /**
      * Assert that the [transform] method extracts default relationships from transformer and
-     * automatically eager loads all relationships.
+     * automatically eager loads all relationships even when the relation name contains include parameters.
      */
     public function testTransformMethodExtractsAndEagerLoadsRelationsWhenThereAreRelationParameters()
     {

--- a/tests/Unit/TransformBuilderTest.php
+++ b/tests/Unit/TransformBuilderTest.php
@@ -336,7 +336,7 @@ class TransformBuilderTest extends TestCase
         //  if it's the same closure reference but no closure are alike, even when they are defined identically.
         // Here we just check that 'bar' element contains a closure.
         $model->shouldHaveReceived('load')->with(Mockery::on(function (array $relations) {
-            return ($relations == 'foo') && ($relations['bar'] instanceof \Closure);
+            return ($relations[0] == 'foo') && ($relations['bar'] instanceof \Closure);
         }))->once();
         $this->transformFactory->shouldHaveReceived('make')->with($this->resource, $this->serializer, [
             'includes' => ['foo:first(aa|bb)', 'bar:second(cc|dd)'],


### PR DESCRIPTION
Now parameters are managed correctly, stripping them away from the relation name before loading it on the model but leaving them when relations are given to the underlying Fractal implementation.
This resolves #83.