### PR TITLE
Transformations now uses a new FractalTransformFactory for every request instead of sharing a singleton

### DIFF
--- a/src/ResponderServiceProvider.php
+++ b/src/ResponderServiceProvider.php
@@ -212,7 +212,7 @@ class ResponderServiceProvider extends BaseServiceProvider
      */
     protected function registerTransformationBindings()
     {
-        $this->app->singleton(TransformFactoryContract::class, function ($app) {
+        $this->app->bind(TransformFactoryContract::class, function ($app) {
             return $app->make(FractalTransformFactory::class);
         });
 


### PR DESCRIPTION
Removed interdependence between transformation requests (which all shared a TransformFactory reference) which led, when using transform helper inside a transformer 'transform()' method, into overwriting the SuccessSerializer with an unwanted NullSerializer. Unit test is not possible, testing is delegated to future Feature tests.

This resolves #86 