### PR TITLE
NullSerializer returns null for null values instead of empty array

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.0",
         "illuminate/contracts": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*",
         "illuminate/support": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*",
         "league/fractal": "^0.16.0"

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "^7.0",
+        "php": "^7.1",
         "illuminate/contracts": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*",
         "illuminate/support": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*",
         "league/fractal": "^0.16.0"

--- a/src/Contracts/TransformFactory.php
+++ b/src/Contracts/TransformFactory.php
@@ -22,5 +22,5 @@ interface TransformFactory
      * @param  array                                         $options
      * @return array|null
      */
-    public function make(ResourceInterface $resource, SerializerAbstract $serializer, array $options = []): ?array;
+    public function make(ResourceInterface $resource, SerializerAbstract $serializer, array $options = []);
 }

--- a/src/Contracts/TransformFactory.php
+++ b/src/Contracts/TransformFactory.php
@@ -20,7 +20,7 @@ interface TransformFactory
      * @param  \League\Fractal\Resource\ResourceInterface    $resource
      * @param  \League\Fractal\Serializer\SerializerAbstract $serializer
      * @param  array                                         $options
-     * @return array
+     * @return array|null
      */
-    public function make(ResourceInterface $resource, SerializerAbstract $serializer, array $options = []): array;
+    public function make(ResourceInterface $resource, SerializerAbstract $serializer, array $options = []): ?array;
 }

--- a/src/Contracts/Transformer.php
+++ b/src/Contracts/Transformer.php
@@ -18,7 +18,7 @@ interface Transformer
      * @param  \Flugg\Responder\Transformers\Transformer|callable|string|null $transformer
      * @param  string[]                                                       $with
      * @param  string[]                                                       $without
-     * @return array
+     * @return array|null
      */
-    public function transform($data = null, $transformer = null, array $with = [], array $without = []): array;
+    public function transform($data = null, $transformer = null, array $with = [], array $without = []): ?array;
 }

--- a/src/Contracts/Transformer.php
+++ b/src/Contracts/Transformer.php
@@ -20,5 +20,5 @@ interface Transformer
      * @param  string[]                                                       $without
      * @return array|null
      */
-    public function transform($data = null, $transformer = null, array $with = [], array $without = []): ?array;
+    public function transform($data = null, $transformer = null, array $with = [], array $without = []);
 }

--- a/src/FractalTransformFactory.php
+++ b/src/FractalTransformFactory.php
@@ -42,7 +42,7 @@ class FractalTransformFactory implements TransformFactory
      * @param  array                                         $options
      * @return array|null
      */
-    public function make(ResourceInterface $resource, SerializerAbstract $serializer, array $options = []): ?array
+    public function make(ResourceInterface $resource, SerializerAbstract $serializer, array $options = [])
     {
         $options = $this->parseOptions($options, $resource);
 

--- a/src/FractalTransformFactory.php
+++ b/src/FractalTransformFactory.php
@@ -40,9 +40,9 @@ class FractalTransformFactory implements TransformFactory
      * @param  \League\Fractal\Resource\ResourceInterface    $resource
      * @param  \League\Fractal\Serializer\SerializerAbstract $serializer
      * @param  array                                         $options
-     * @return array
+     * @return array|null
      */
-    public function make(ResourceInterface $resource, SerializerAbstract $serializer, array $options = []): array
+    public function make(ResourceInterface $resource, SerializerAbstract $serializer, array $options = []): ?array
     {
         $options = $this->parseOptions($options, $resource);
 

--- a/src/Serializers/NullSerializer.php
+++ b/src/Serializers/NullSerializer.php
@@ -45,7 +45,7 @@ class NullSerializer extends SuccessSerializer
      */
     public function null()
     {
-        return [];
+        return null;
     }
 
     /**

--- a/src/Serializers/SuccessSerializer.php
+++ b/src/Serializers/SuccessSerializer.php
@@ -102,16 +102,6 @@ class SuccessSerializer extends ArraySerializer
     }
 
     /**
-     * Indicates if includes should be side-loaded.
-     *
-     * @return bool
-     */
-    public function sideloadIncludes()
-    {
-        return true;
-    }
-
-    /**
      * Merge includes into data.
      *
      * @param  array $transformedData
@@ -125,17 +115,5 @@ class SuccessSerializer extends ArraySerializer
         }
 
         return array_merge($transformedData, $includedData);
-    }
-
-    /**
-     * Format the included data.
-     *
-     * @param  \League\Fractal\Resource\ResourceInterface $resource
-     * @param  array                                      $data
-     * @return array
-     */
-    public function includedData(ResourceInterface $resource, array $data)
-    {
-        return [];
     }
 }

--- a/src/TransformBuilder.php
+++ b/src/TransformBuilder.php
@@ -226,7 +226,7 @@ class TransformBuilder
      *
      * @return array|null
      */
-    public function transform(): ?array
+    public function transform()
     {
         $this->prepareRelations($this->resource->getData(), $this->resource->getTransformer());
 

--- a/src/TransformBuilder.php
+++ b/src/TransformBuilder.php
@@ -224,9 +224,9 @@ class TransformBuilder
     /**
      * Transform and serialize the data and return the transformed array.
      *
-     * @return array
+     * @return array|null
      */
-    public function transform(): array
+    public function transform(): ?array
     {
         $this->prepareRelations($this->resource->getData(), $this->resource->getTransformer());
 

--- a/src/Transformer.php
+++ b/src/Transformer.php
@@ -40,7 +40,7 @@ class Transformer implements TransformerContract
      * @param  string[]                                                       $without
      * @return array|null
      */
-    public function transform($data = null, $transformer = null, array $with = [], array $without = []): ?array
+    public function transform($data = null, $transformer = null, array $with = [], array $without = [])
     {
         return $this->transformBuilder->resource($data, $transformer)
             ->with($with)

--- a/src/Transformer.php
+++ b/src/Transformer.php
@@ -38,9 +38,9 @@ class Transformer implements TransformerContract
      * @param  \Flugg\Responder\Transformers\Transformer|callable|string|null $transformer
      * @param  string[]                                                       $with
      * @param  string[]                                                       $without
-     * @return array
+     * @return array|null
      */
-    public function transform($data = null, $transformer = null, array $with = [], array $without = []): array
+    public function transform($data = null, $transformer = null, array $with = [], array $without = []): ?array
     {
         return $this->transformBuilder->resource($data, $transformer)
             ->with($with)

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -25,9 +25,9 @@ if (! function_exists('transform')) {
      * @param  \Flugg\Responder\Transformers\Transformer|callable|string|null $transformer
      * @param  string[]                                                       $with
      * @param  string[]                                                       $without
-     * @return array
+     * @return array|null
      */
-    function transform($data = null, $transformer = null, array $with = [], array $without = []): array
+    function transform($data = null, $transformer = null, array $with = [], array $without = []): ?array
     {
         return app(Transformer::class)->transform($data, $transformer, $with, $without);
     }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -27,7 +27,7 @@ if (! function_exists('transform')) {
      * @param  string[]                                                       $without
      * @return array|null
      */
-    function transform($data = null, $transformer = null, array $with = [], array $without = []): ?array
+    function transform($data = null, $transformer = null, array $with = [], array $without = [])
     {
         return app(Transformer::class)->transform($data, $transformer, $with, $without);
     }

--- a/tests/Unit/Serializers/NullSerializerTest.php
+++ b/tests/Unit/Serializers/NullSerializerTest.php
@@ -57,13 +57,13 @@ class NullSerializerTest extends TestCase
     }
 
     /**
-     * Assert that the [null] method returns an empty array.
+     * Assert that the [null] method returns null.
      */
-    public function testNullMethodShouldReturnAnEmptyArray()
+    public function testNullMethodShouldReturnNull()
     {
         $result = $this->serializer->null();
 
-        $this->assertEquals([], $result);
+        $this->assertEquals(null, $result);
     }
 
     /**

--- a/tests/Unit/Serializers/SuccessSerializerTest.php
+++ b/tests/Unit/Serializers/SuccessSerializerTest.php
@@ -130,16 +130,6 @@ class SuccessSerializerTest extends TestCase
     }
 
     /**
-     * Assert that the [sideloadIncludes] method returns true.
-     */
-    public function testSideloadIncludesMethodShouldReturnTrue()
-    {
-        $result = $this->serializer->sideloadIncludes();
-
-        $this->assertTrue($result);
-    }
-
-    /**
      * Assert that the [mergeIncludes] method merges relations and strips away extra data fields.
      */
     public function testMergeIncludesMethodShouldMergeRelationsAndStripDataFields()
@@ -147,15 +137,5 @@ class SuccessSerializerTest extends TestCase
         $result = $this->serializer->mergeIncludes($data = ['foo' => 1], $relations = ['bar' => ['data' => 2]]);
 
         $this->assertEquals(['foo' => 1, 'bar' => 2], $result);
-    }
-
-    /**
-     * Assert that the [includedData] method returns an empty array.
-     */
-    public function testIncludedDataMethodShouldReturnAnEmptyArray()
-    {
-        $result = $this->serializer->includedData($resource = new Item, ['foo' => 1]);
-
-        $this->assertEquals([], $result);
     }
 }


### PR DESCRIPTION
This solves #82.
A Feature test suite is required to test this extensively.
**_May_** require to increment major version number given that null data, previously transformed as an empty array, is now returned as null as it should be.
I don't know for certain if this shall be considered as a bugfix (the array representation wasn't the intended behaviour in first place as I understood), a retro-compatible change or a breaking change.
I think it could be intended as a retro-compatible change, given that it bring with it also an update on the needed required PHP version (7.0 -> 7.1). The change can be done also avoiding to update the PHP version dependency if needed.