### PR TITLE
EscapeHtmlDecorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,11 +251,20 @@ return responder()->error()->decorator(ExampleDecorator::class)->respond();
 ```
 
 ***
-_The package also ships with a `PrettyPrintDecorator` decorator which will beautify the JSON output. This is disabled by default, but can be added to the decorator list:_
+
+The package also ships with some situational decorators disabled by default, but which can be added to the decorator list: 
+- `PrettyPrintDecorator` decorator will beautify the JSON output;
 
 ```php
 \Flugg\Responder\Http\Responses\Decorators\PrettyPrintDecorator::class,
 ```
+
+- `EscapeHtmlDecorator` decorator, based on the "sanitize input, escape output" concept, will escape HTML entities in all strings returned by your API. You can securely store input data "as is" (even malicious HTML tags) being sure that it will be outputted as un-harmful strings. Note that, using this decorator, printing data as text will result in the wrong representation and you **must** print it as HTML to retrieve the original value.
+
+```php
+\Flugg\Responder\Http\Responses\Decorators\EscapeHtmlDecorator::class,
+```
+
 ***
 
 ## Creating Success Responses

--- a/src/Http/Responses/Decorators/EscapeHtmlDecorator.php
+++ b/src/Http/Responses/Decorators/EscapeHtmlDecorator.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Support;
+
+use Flugg\Responder\Http\Responses\Decorators\ResponseDecorator;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * A decorator class which escapes HTML entities in strings returned by your API.
+ *
+ * @package flugger/laravel-responder
+ * @author  Paolo Caleffi <p.caleffi@dreamonkey.com>
+ * @license The MIT License
+ */
+class EscapeHtmlDecorator extends ResponseDecorator
+{
+    /**
+     * Generate a JSON response.
+     *
+     * @param  array $data
+     * @param  int $status
+     * @param  array $headers
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function make(array $data, int $status, array $headers = []): JsonResponse
+    {
+        array_walk_recursive($data, function (&$value) {
+            if(is_string($value)) {
+                $value = e($value);
+            }
+        });
+
+        return $this->factory->make($data, $status, $headers);
+    }
+}


### PR DESCRIPTION
I think that this simple decorator can be a precious ally to prevent XSS attacks when the API consumer is a web-client which will print user generated data into a page.
It's based on "sanitize input, encode output" paradigm.
There are usually two scenarios here and I have in mind the "always use the safer default" idea.
The hypothesis is that we stored data into our database "as is", which is the way I usually prefer because I don't want to ruin data I collect.

We can return it "as is", in which case if the developer print it as HTML by mistake we'll have an XSS attack, or we can return it escaped, in which case if the developer prints it as text by mistake it will display as an ugly string.
I prefer the latter, hence I created this decorator.

If you think there is a more efficient way to achieve the same goal, I'm open to advices.