### PR TITLE
null as default resourceKey #115

### DIFF
--- a/src/Resources/ResourceKeyResolver.php
+++ b/src/Resources/ResourceKeyResolver.php
@@ -40,7 +40,7 @@ class ResourceKeyResolver implements ResourceKeyResolverContract
      * Resolve a resource key from the given data.
      *
      * @param  mixed $data
-     * @return string
+     * @return string|null
      */
     public function resolve($data)
     {
@@ -54,7 +54,7 @@ class ResourceKeyResolver implements ResourceKeyResolverContract
             return $this->resolveFromModel($transformable);
         }
 
-        return 'data';
+        return null;
     }
 
     /**

--- a/tests/Unit/Resources/ResolveResourceKeyTest.php
+++ b/tests/Unit/Resources/ResolveResourceKeyTest.php
@@ -36,14 +36,14 @@ class ResolveResourceKeyTest extends TestCase
     }
 
     /**
-     * Assert that the [resolve] method resolves 'data' as resource key if it can't resolve
+     * Assert that the [resolve] method resolves null as resource key if it can't resolve
      * a resource key from the given data.
      */
     public function testResolveMethodShouldResolveDefaultResourceKeyIfNoneIsFound()
     {
         $result = $this->resolver->resolve($data = []);
 
-        $this->assertEquals('data', $result);
+        $this->assertEquals(null, $result);
     }
 
     /**


### PR DESCRIPTION
hello handsome mustache! I made small PR for trying to fix #115,

seems returning null as resourceKey is looks fine. 

|Serializer | Available ResourceKey|
|----|----|
|SuccessSerializer| 'data'|
|ArraySerializer|$resourceKey or nothing|
|NoopSerializer|nothing|

should I add more 'feature' test case for it?