### PR TITLE
Fix bug do not send headers in response

### DIFF
--- a/src/Exceptions/ConvertsExceptions.php
+++ b/src/Exceptions/ConvertsExceptions.php
@@ -85,6 +85,6 @@ trait ConvertsExceptions
         return app(Responder::class)
             ->error($exception->errorCode(), $exception->message())
             ->data($exception->data())
-            ->respond($exception->statusCode());
+            ->respond($exception->statusCode(), $exception->getHeaders());
     }
 }


### PR DESCRIPTION
_I created an http error with custom header. But the header was not sent as a response. And I fixed it_