### PR TITLE
trans() method to get() for Laravel 6.0

### DIFF
--- a/src/ErrorMessageResolver.php
+++ b/src/ErrorMessageResolver.php
@@ -65,7 +65,7 @@ class ErrorMessageResolver implements ErrorMessageResolverContract
         }
 
         if ($this->translator->has($errorCode = "errors.$errorCode")) {
-            return $this->translator->trans($errorCode);
+            return $this->translator->get($errorCode);
         }
 
         return null;

--- a/tests/Unit/ErrorMessageResolverTest.php
+++ b/tests/Unit/ErrorMessageResolverTest.php
@@ -61,13 +61,13 @@ class ErrorMessageResolverTest extends TestCase
     public function testResolveMethodShouldResolveMessageFromTranslator()
     {
         $this->translator->shouldReceive('has')->andReturn(true);
-        $this->translator->shouldReceive('trans')->andReturn($message = 'A test error has occured.');
+        $this->translator->shouldReceive('get')->andReturn($message = 'A test error has occured.');
 
         $result = $this->messageResolver->resolve($code = 'test_error');
 
         $this->assertEquals($message, $result);
         $this->translator->shouldHaveReceived('has')->with("errors.$code")->once();
-        $this->translator->shouldHaveReceived('trans')->with("errors.$code")->once();
+        $this->translator->shouldHaveReceived('get')->with("errors.$code")->once();
     }
 
     /**


### PR DESCRIPTION
They removed trans() method from Translator class on Laravel 6.0, get() method should be used instead of it. It is also valid for previous releases.

https://github.com/laravel/framework/commit/8557dc56b11c5e4dc746cb5558d6e694131f0dd8#diff-aebbba80d9a2718c0fe6105c28bd4813
