### PR TITLE
str and array helpers converted to support classes for Laravel 6.0

### DIFF
--- a/src/Console/MakeTransformer.php
+++ b/src/Console/MakeTransformer.php
@@ -3,6 +3,8 @@
 namespace Flugg\Responder\Console;
 
 use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Symfony\Component\Console\Input\InputOption;
 
 /**
@@ -88,7 +90,7 @@ class MakeTransformer extends GeneratorCommand
      */
     protected function resolveModelFromClassName()
     {
-        return 'App\\' . str_replace('Transformer', '', array_last(explode('/', $this->getNameInput())));
+        return 'App\\' . str_replace('Transformer', '', Arr::last(explode('/', $this->getNameInput())));
     }
 
     /**
@@ -126,7 +128,7 @@ class MakeTransformer extends GeneratorCommand
 
         $model = trim(str_replace('/', '\\', $model), '\\');
 
-        if (! starts_with($model, $rootNamespace = $this->laravel->getNamespace())) {
+        if (! Str::startsWith($model, $rootNamespace = $this->laravel->getNamespace())) {
             $model = $rootNamespace . $model;
         }
 

--- a/src/TransformBuilder.php
+++ b/src/TransformBuilder.php
@@ -11,6 +11,7 @@ use Flugg\Responder\Transformers\Transformer;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
 use League\Fractal\Pagination\Cursor;
 use League\Fractal\Pagination\IlluminatePaginatorAdapter;
 use League\Fractal\Resource\Collection as CollectionResource;
@@ -306,7 +307,7 @@ class TransformBuilder
     protected function eagerLoadRelations($data, array $requested, $transformer)
     {
         $relations = collect(array_keys($requested))->reduce(function ($eagerLoads, $relation) use ($requested, $transformer) {
-            $identifier = camel_case($this->stripParametersFromRelation($relation));
+            $identifier = Str::camel($this->stripParametersFromRelation($relation));
 
             if (method_exists($transformer, 'include' . ucfirst($identifier))) {
                 return $eagerLoads;

--- a/src/Transformers/Concerns/HasRelationships.php
+++ b/src/Transformers/Concerns/HasRelationships.php
@@ -3,6 +3,7 @@
 namespace Flugg\Responder\Transformers\Concerns;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 
 /**
  * A trait to be used by a transformer to handle relations
@@ -105,7 +106,7 @@ trait HasRelationships
 
             return [$identifier => $constraint ?: $this->resolveQueryConstraint($identifier)];
         }), function ($relation) use ($available) {
-            return array_has($available, explode(':', $relation)[0]);
+            return Arr::has($available, explode(':', $relation)[0]);
         }, ARRAY_FILTER_USE_KEY);
     }
 

--- a/src/Transformers/Concerns/HasRelationships.php
+++ b/src/Transformers/Concerns/HasRelationships.php
@@ -4,6 +4,7 @@ namespace Flugg\Responder\Transformers\Concerns;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 
 /**
  * A trait to be used by a transformer to handle relations
@@ -120,7 +121,7 @@ trait HasRelationships
     protected function extractChildRelations(array $relations, string $identifier): array
     {
         return array_reduce(array_keys($relations), function ($nested, $relation) use ($relations, $identifier) {
-            if (! starts_with($relation, "$identifier.")) {
+            if (! Str::startsWith($relation, "$identifier.")) {
                 return $nested;
             }
 
@@ -202,7 +203,7 @@ trait HasRelationships
      */
     protected function resolveQueryConstraint(string $identifier)
     {
-        if (! method_exists($this, $method = 'load' . ucfirst(camel_case($identifier)))) {
+        if (! method_exists($this, $method = 'load' . ucfirst(Str::camel($identifier)))) {
             return null;
         }
 
@@ -220,7 +221,7 @@ trait HasRelationships
      */
     protected function resolveRelation(Model $model, string $identifier)
     {
-        $identifier = camel_case($identifier);
+        $identifier = Str::camel($identifier);
         $relation = $model->$identifier;
 
         if (method_exists($this, $method = 'filter' . ucfirst($identifier))) {

--- a/src/Transformers/Concerns/MakesResources.php
+++ b/src/Transformers/Concerns/MakesResources.php
@@ -6,6 +6,7 @@ use Countable;
 use Flugg\Responder\Contracts\Resources\ResourceFactory;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
 use League\Fractal\Resource\ResourceInterface;
 use LogicException;
 
@@ -57,7 +58,7 @@ trait MakesResources
     {
         $transformer = $this->mappedTransformerClass($identifier);
 
-        if (method_exists($this, $method = 'include' . ucfirst(camel_case($identifier)))) {
+        if (method_exists($this, $method = 'include' . ucfirst(Str::camel($identifier)))) {
             $resource = $this->resource($this->$method($data, collect($parameters)), $transformer, $identifier);
         } elseif ($data instanceof Model) {
             $resource = $this->includeResourceFromModel($data, $identifier, $transformer);

--- a/tests/Feature/IncludeRelationTest.php
+++ b/tests/Feature/IncludeRelationTest.php
@@ -8,6 +8,7 @@ use Flugg\Responder\Tests\Product;
 use Flugg\Responder\Tests\ProductTransformer;
 use Flugg\Responder\Tests\TestCase;
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Mockery;
 
@@ -131,7 +132,7 @@ class IncludeRelationTest extends TestCase
         ])->respond();
 
         $product->shouldHaveReceived('load')->with(Mockery::on(function ($argument) {
-            return array_has($argument, 'orders') && is_callable($argument['orders']) && count($argument) === 2;
+            return Arr::has($argument, 'orders') && is_callable($argument['orders']) && count($argument) === 2;
         }))->once();
     }
 
@@ -223,7 +224,7 @@ class IncludeRelationTest extends TestCase
             ->respond();
 
         $product->shouldHaveReceived('load')->with(Mockery::on(function ($argument) {
-            return array_has($argument, 'shipments') && count($argument) === 1;
+            return Arr::has($argument, 'shipments') && count($argument) === 1;
         }))->once();
     }
 
@@ -242,7 +243,7 @@ class IncludeRelationTest extends TestCase
             ->respond();
 
         $product->shouldHaveReceived('load')->with(Mockery::on(function ($argument) {
-            return array_has($argument, ['whitelistedShipments', 'defaultOrders']) && count($argument) === 2;
+            return Arr::has($argument, ['whitelistedShipments', 'defaultOrders']) && count($argument) === 2;
         }))->once();
     }
 
@@ -260,7 +261,7 @@ class IncludeRelationTest extends TestCase
             ->respond();
 
         $product->shouldHaveReceived('load')->with(Mockery::on(function ($argument) {
-            return array_has($argument, 'orders') && count($argument) === 1;
+            return Arr::has($argument, 'orders') && count($argument) === 1;
         }))->once();
         $this->assertEquals($this->responseData(array_merge($this->product->fresh()->toArray(), [
             'shipments' => [$this->shipment->toArray()],

--- a/tests/Unit/TransformBuilderTest.php
+++ b/tests/Unit/TransformBuilderTest.php
@@ -14,6 +14,7 @@ use Flugg\Responder\TransformBuilder;
 use Flugg\Responder\Transformers\Transformer;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 use League\Fractal\Pagination\Cursor;
 use League\Fractal\Pagination\IlluminatePaginatorAdapter;
 use League\Fractal\Serializer\JsonApiSerializer;
@@ -309,7 +310,7 @@ class TransformBuilderTest extends TestCase
         $this->builder->resource()->with($relations = ['foo' => function () { }, 'bar'])->transform();
 
         $model->shouldHaveReceived('load')->with(Mockery::on(function ($argument) {
-            return array_has($argument, ['foo', 'bar', 'baz']);
+            return Arr::has($argument, ['foo', 'bar', 'baz']);
         }))->once();
         $this->transformFactory->shouldHaveReceived('make')->with($this->resource, $this->serializer, [
             'includes' => ['foo', 'bar', 'baz'],
@@ -335,7 +336,7 @@ class TransformBuilderTest extends TestCase
         $this->builder->resource()->with(['foo:first(aa|bb)', 'bar:second(cc|dd)'])->transform();
 
         $model->shouldHaveReceived('load')->with(Mockery::on(function ($argument) {
-            return array_has($argument, ['foo', 'bar']);
+            return Arr::has($argument, ['foo', 'bar']);
         }))->once();
         $this->transformFactory->shouldHaveReceived('make')->with($this->resource, $this->serializer, [
             'includes' => ['foo:first(aa|bb)', 'bar:second(cc|dd)'],
@@ -359,7 +360,7 @@ class TransformBuilderTest extends TestCase
         $this->builder->resource()->with(['foo', 'bar'])->transform();
 
         $model->shouldHaveReceived('load')->with(Mockery::on(function ($argument) {
-            return array_has($argument, 'foo') && count($argument) === 1;
+            return Arr::has($argument, 'foo') && count($argument) === 1;
         }))->once();
         $this->transformFactory->shouldHaveReceived('make')->with($this->resource, $this->serializer, [
             'includes' => ['foo'],
@@ -386,7 +387,7 @@ class TransformBuilderTest extends TestCase
         $this->builder->resource()->with($relations = ['foo', 'bar'])->transform();
 
         $model->shouldHaveReceived('load')->with(Mockery::on(function ($argument) {
-            return array_has($argument, 'foo') && count($argument) === 1;
+            return Arr::has($argument, 'foo') && count($argument) === 1;
         }))->once();
         $this->transformFactory->shouldHaveReceived('make')->with($this->resource, $this->serializer, [
             'includes' => ['foo', 'bar', 'baz'],


### PR DESCRIPTION
array_ and str_ helpers are removed and transferred to laravel/helpers package. So these methods don't work on Laravel 6.0

I have converted them to current way recommended on Laravel documentation.

https://laravel.com/docs/6.0/upgrade#helpers