### PR TITLE
add non camel-case relations support

### DIFF
--- a/config/responder.php
+++ b/config/responder.php
@@ -99,4 +99,16 @@ return [
 
     'error_message_files' => ['errors'],
 
+    /*
+    |--------------------------------------------------------------------------
+    | CamelCase Relations
+    |--------------------------------------------------------------------------
+    |
+    | By default laravel responder will convert relations request to camel-case
+    | but some people would like to use snake-case, so you can set it below
+    |
+    */
+
+    'use_camel_case_relations' => true,
+
 ];

--- a/src/TransformBuilder.php
+++ b/src/TransformBuilder.php
@@ -307,7 +307,11 @@ class TransformBuilder
     protected function eagerLoadRelations($data, array $requested, $transformer)
     {
         $relations = collect(array_keys($requested))->reduce(function ($eagerLoads, $relation) use ($requested, $transformer) {
-            $identifier = Str::camel($this->stripParametersFromRelation($relation));
+            $identifier = $this->stripParametersFromRelation($relation);
+
+            if(config('responder.use_camel_case_relations')) {
+                $identifier = Str::camel($identifier);
+            }
 
             if (method_exists($transformer, 'include' . ucfirst($identifier))) {
                 return $eagerLoads;

--- a/src/Transformers/Concerns/HasRelationships.php
+++ b/src/Transformers/Concerns/HasRelationships.php
@@ -203,7 +203,11 @@ trait HasRelationships
      */
     protected function resolveQueryConstraint(string $identifier)
     {
-        if (! method_exists($this, $method = 'load' . ucfirst(Str::camel($identifier)))) {
+        if(config('responder.use_camel_case_relations')) {
+            $identifier = Str::camel($identifier);
+        }
+
+        if (! method_exists($this, $method = 'load' . ucfirst($identifier))) {
             return null;
         }
 
@@ -221,7 +225,10 @@ trait HasRelationships
      */
     protected function resolveRelation(Model $model, string $identifier)
     {
-        $identifier = Str::camel($identifier);
+        if(config('responder.use_camel_case_relations')) {
+            $identifier = Str::camel($identifier);
+        }
+
         $relation = $model->$identifier;
 
         if (method_exists($this, $method = 'filter' . ucfirst($identifier))) {

--- a/src/Transformers/Concerns/MakesResources.php
+++ b/src/Transformers/Concerns/MakesResources.php
@@ -58,7 +58,11 @@ trait MakesResources
     {
         $transformer = $this->mappedTransformerClass($identifier);
 
-        if (method_exists($this, $method = 'include' . ucfirst(Str::camel($identifier)))) {
+        if(config('responder.use_camel_case_relations')) {
+            $identifier = Str::camel($identifier);
+        }
+
+        if (method_exists($this, $method = 'include' . ucfirst($identifier))) {
             $resource = $this->resource($this->$method($data, collect($parameters)), $transformer, $identifier);
         } elseif ($data instanceof Model) {
             $resource = $this->includeResourceFromModel($data, $identifier, $transformer);

--- a/tests/Feature/IncludeRelationTest.php
+++ b/tests/Feature/IncludeRelationTest.php
@@ -248,6 +248,26 @@ class IncludeRelationTest extends TestCase
     }
 
     /**
+     * Assert that it would not converts snake cased relations to camel case before loading them
+     * from the model if the config use_camel_case_relations set to false
+     */
+    public function testItNotConvertsSnakeCasedRelationsToCamelCase()
+    {
+        config(['responder.use_camel_case_relations' => false]);
+        $product = Mockery::mock($this->product);
+        $product->shouldReceive('load')->andReturnSelf();
+
+        responder()
+            ->success($product, ProductWithSnakeCasedRelationsTransformer::class)
+            ->with('whitelisted_shipments', 'default_orders')
+            ->respond();
+
+        $product->shouldHaveReceived('load')->with(Mockery::on(function ($argument) {
+            return Arr::has($argument, ['whitelisted_shipments', 'default_orders']) && count($argument) === 2;
+        }))->once();
+    }
+
+    /**
      * Assert that it loads relations from an "include" method on the transformer if it's
      * defined.
      */


### PR DESCRIPTION
i have existing project that use non camel case relation method, when using laravel responder which convert all relations to camelcase make it fail to work,, so i add config to enable/disable camel-case convert, by default is using camel-case, but if we want to disable it just set it on config:
use_camel_case_relations => false